### PR TITLE
fix: add deterministic ordering to sorting logic to handle ties by link

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,7 +193,13 @@ func visitPage(url string, items *[]blogItem, tags map[string]bool, wg *sync.Wai
 
 func generateFeeds(blogItems *[]blogItem, feedName string) error {
 	sort.Slice(*blogItems, func(i, j int) bool {
-		return (*blogItems)[i].PubDate.After((*blogItems)[j].PubDate)
+		if (*blogItems)[i].PubDate.After((*blogItems)[j].PubDate) {
+			return true
+		}
+		if (*blogItems)[i].PubDate.Before((*blogItems)[j].PubDate) {
+			return false
+		}
+		return (*blogItems)[i].Link < (*blogItems)[j].Link
 	})
 
 	err := generateItemFeed(blogItems, fmt.Sprintf("%s_feed_items", feedName))


### PR DESCRIPTION
Fixes sorting logic to handle instances where posts have the same publish date by using the post URL to determine a static order. This ensures posts with the same publish date are sorted in a consistent order in the generated feeds.

## Changes made 
- Updated sorting logic
- Rebuilt Linux binary