### PR TITLE
chore: update branch name from master to main in workflow configuration

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 1 * * *'
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Fixes typo within the GitHub Actions workflow configuration. Updates the default branch for the `push` event trigger from `master` to `main`.